### PR TITLE
Use same options in proto compile and load

### DIFF
--- a/examples/grpc-proto-loader/client.ts
+++ b/examples/grpc-proto-loader/client.ts
@@ -4,7 +4,12 @@ import { ProtoGrpcType } from './proto/example';
 import { ServerMessage } from './proto/example_package/ServerMessage';
 
 const host = '0.0.0.0:9090';
-const packageDefinition = protoLoader.loadSync('./proto/example.proto');
+const packageDefinition = protoLoader.loadSync('./proto/example.proto', {
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
 const proto = grpc.loadPackageDefinition(
   packageDefinition
 ) as unknown as ProtoGrpcType;

--- a/examples/grpc-proto-loader/server.ts
+++ b/examples/grpc-proto-loader/server.ts
@@ -53,7 +53,12 @@ const exampleServer: ExampleHandlers = {
 };
 
 function getServer(): grpc.Server {
-  const packageDefinition = protoLoader.loadSync('./proto/example.proto');
+  const packageDefinition = protoLoader.loadSync('./proto/example.proto', {
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
   const proto = grpc.loadPackageDefinition(
     packageDefinition
   ) as unknown as ProtoGrpcType;


### PR DESCRIPTION
First of all, thank you for this example repository! I've been using it as a reference countless times while writing TypeScript services.

---

I've noticed a small footgun in `proto-loader` example:

When using the flags `--oneofs` for the `build:proto` step, the generated code provides a virtual property for each `oneof` message type.
However, if the same option is not used in `loadSync` method, the virtual property is always undefined.

I've added the options to match those used in the `build:proto`, so people in the future will avoid the same mistake.